### PR TITLE
Fixes

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -24,10 +24,10 @@ core:
       all_discussions_label: => core.ref.all_discussions
       default_language_heading: Deutsch
       forum_description_heading: Beschreibung des Forums
-      forum_description_text: Kurze Beschreibung des Forums. Diese wird in in den meta-Tags der Suchmaschienen erscheinen.
-      forum_title_heading: Title des Forums
+      forum_description_text: Kurze Beschreibung des Forums. Diese wird in in den meta-Tags der Suchmaschinen erscheinen.
+      forum_title_heading: Titel des Forums
       home_page_heading: Startseite
-      home_page_text: "Welsche Seite sollen Besucher*innen als erstes sehen? Bitte ggf. den relativen Pfad zum Forum eingeben "
+      home_page_text: "Welche Seite sollen Besucher*innen als erstes sehen? Bitte ggf. den relativen Pfad zum Forum eingeben "
       saved_message: Die Veränderungen wurden übernommen.
       submit_button: => core.ref.save_changes
       welcome_banner_heading: Willkommensnachricht
@@ -51,8 +51,8 @@ core:
       icon_label: Symbol
       icon_text: "Name des <a>FontAwesome</a>-Symbols eingeben, aber <em>ohne</em> den Prefix <code>fa-</code>."
       name_label: Name
-      plural_placeholder: Name in der Mehrzahl (e.g. Mods)
-      singular_placeholder: Name in der Einzahl (e.g. Mod)
+      plural_placeholder: Einzahl (e.g. Mods)
+      singular_placeholder: Mehrzahl (e.g. Mod)
       submit_button: => core.ref.save_changes
       title: Gruppe erstellen
 
@@ -88,12 +88,12 @@ core:
     # These strings are used in the Permissions page of the admin interface.
     permissions:
       allow_renaming_label: Erlaube Umbenennungen
-      allow_post_editing_label: Erlaube Beiträge zu ändern
+      allow_post_editing_label: Erlaube das Ändern von Beiträgen
       create_heading: Erstellen
-      delete_discussions_forever_label: Lösche die Diskussion entgültig
-      delete_discussions_label: Lösche die Diskussion
-      delete_posts_forever_label: Beitrag entgültig löschen
-      edit_and_delete_posts_label: Beiträge änderen und löschen
+      delete_discussions_forever_label: Diskussion endgültig löschen
+      delete_discussions_label: Diskussion löschen
+      delete_posts_forever_label: Beitrag endgültig löschen
+      edit_and_delete_posts_label: Beitrag ändern/löschen
       global_heading: Global
       moderate_heading: Moderieren
       new_group_button: Neue Gruppe
@@ -109,9 +109,9 @@ core:
     permissions_controls:
       allow_indefinitely_button: Immer
       allow_some_minutes_button: "Für {count} Minute|Für {count} Minuten"
-      allow_ten_minutes_button: Für zehn Minuten
-      allow_until_reply_button: Vor einer Antwort
-      everyone_button: Alle
+      allow_ten_minutes_button: Für 10 Minuten
+      allow_until_reply_button: Bis zur nächsten Antwort
+      everyone_button: Jede*r
       members_button: => core.group.members
       signup_closed_button: Geschlossen
       signup_open_button: Offen
@@ -176,7 +176,7 @@ core:
 
     # These strings are used in the discussion list.
     discussion_list:
-      empty_text: "Noch keine (öffentlichen) Diskussionen in diesem Forum."
+      empty_text: "Noch keine Diskussionen in diesem Forum."
       load_more_button: => core.ref.load_more
       mark_as_read_tooltip: Als gelesen makieren
       replied_text: "{ago} von {username} beantwortet"

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -24,10 +24,10 @@ core:
       all_discussions_label: => core.ref.all_discussions
       default_language_heading: Deutsch
       forum_description_heading: Beschreibung des Forums
-      forum_description_text: Kurze Beschreibung des Forums. Diese wird in in den meta-Tags der Suchmaschinen erscheinen.
-      forum_title_heading: Titel des Forums
+      forum_description_text: Kurze Beschreibung des Forums. Diese wird in in den meta-Tags der Suchmaschienen erscheinen.
+      forum_title_heading: Title des Forums
       home_page_heading: Startseite
-      home_page_text: "Welche Seite sollen Besucher*innen als erstes sehen? Bitte ggf. den relativen Pfad zum Forum eingeben."
+      home_page_text: "Welsche Seite sollen Besucher*innen als erstes sehen? Bitte ggf. den relativen Pfad zum Forum eingeben "
       saved_message: Die Veränderungen wurden übernommen.
       submit_button: => core.ref.save_changes
       welcome_banner_heading: Willkommensnachricht
@@ -88,7 +88,7 @@ core:
     # These strings are used in the Permissions page of the admin interface.
     permissions:
       allow_renaming_label: Erlaube Umbenennungen
-      allow_post_editing_label: Erlaube das Editieren von Beiträgen
+      allow_post_editing_label: Erlaube das Änderen von Beitragen
       create_heading: Erstellen
       delete_discussions_forever_label: Lösche die Diskussion entgültig
       delete_discussions_label: Lösche die Diskussion
@@ -103,7 +103,7 @@ core:
       reply_to_discussions_label: Antworte auf die Diskussion
       sign_up_label: Registrierung
       start_discussions_label:  Diskussion beginnen
-      view_discussions_label: Diskussion lesen
+      view_discussions_label: Diskussionen lesen
 
     # These strings are used in the dropdown menus on the Permissions page.
     permissions_controls:

--- a/locale/core.yml
+++ b/locale/core.yml
@@ -24,10 +24,10 @@ core:
       all_discussions_label: => core.ref.all_discussions
       default_language_heading: Deutsch
       forum_description_heading: Beschreibung des Forums
-      forum_description_text: Kurze Beschreibung des Forums. Diese wird in in den meta-Tags der Suchmaschienen erscheinen.
-      forum_title_heading: Title des Forums
+      forum_description_text: Kurze Beschreibung des Forums. Diese wird in in den meta-Tags der Suchmaschinen erscheinen.
+      forum_title_heading: Titel des Forums
       home_page_heading: Startseite
-      home_page_text: "Welsche Seite sollen Besucher*innen als erstes sehen? Bitte ggf. den relativen Pfad zum Forum eingeben "
+      home_page_text: "Welche Seite sollen Besucher*innen als erstes sehen? Bitte ggf. den relativen Pfad zum Forum eingeben."
       saved_message: Die Veränderungen wurden übernommen.
       submit_button: => core.ref.save_changes
       welcome_banner_heading: Willkommensnachricht
@@ -88,7 +88,7 @@ core:
     # These strings are used in the Permissions page of the admin interface.
     permissions:
       allow_renaming_label: Erlaube Umbenennungen
-      allow_post_editing_label: Erlaube das Änderen von Beitragen
+      allow_post_editing_label: Erlaube das Editieren von Beiträgen
       create_heading: Erstellen
       delete_discussions_forever_label: Lösche die Diskussion entgültig
       delete_discussions_label: Lösche die Diskussion
@@ -103,7 +103,7 @@ core:
       reply_to_discussions_label: Antworte auf die Diskussion
       sign_up_label: Registrierung
       start_discussions_label:  Diskussion beginnen
-      view_discussions_label: Diskussionen lesen
+      view_discussions_label: Diskussion lesen
 
     # These strings are used in the dropdown menus on the Permissions page.
     permissions_controls:

--- a/locale/flarum-lock.yml
+++ b/locale/flarum-lock.yml
@@ -9,7 +9,7 @@ flarum-lock:
 
     # These strings are used in the Permissions page of the admin interface.
     permissions:
-      lock_discussions_label: Diskussionen schließen
+      lock_discussions_label: Diskussion schließen
 
   # Strings in this namespace are used by the forum user interface.
   forum:

--- a/locale/flarum-mentions.yml
+++ b/locale/flarum-mentions.yml
@@ -20,7 +20,7 @@ flarum-mentions:
     # These strings are displayed beneath individual posts.
     post:
       mentioned_by_self_text: "{username} hat auf deinen Beitrag geantwortet.|{username} haben auf deinen Beitrag geantwortet."  # Can be pluralized to agree with the number of users!
-      mentioned_by_text: "{username} hat auf deinen Beitrag geantwortet.|{username} haben auf deinen Beitrag geantwortet."       # Can be pluralized to agree with the number of users!
+      mentioned_by_text: "{username} hat auf diesen Beitrag geantwortet.|{username} haben auf diesen Beitrag geantwortet."       # Can be pluralized to agree with the number of users!
       others_text: => core.ref.some_others
       reply_link: => core.ref.reply
       you_text: => core.ref.you

--- a/locale/flarum-sticky.yml
+++ b/locale/flarum-sticky.yml
@@ -16,7 +16,7 @@ flarum-sticky:
 
     # These strings are displayed as tooltips for discussion badges.
     badge:
-      sticky_tooltip: => flarum-sticky.ref.sticky
+      sticky_tooltip: Angepinnt
 
     # These strings are used by the discussion control buttons.
     discussion_controls:
@@ -26,7 +26,7 @@ flarum-sticky:
     # These strings are displayed between posts in the post stream.
     post_stream:
       discussion_stickied_text: "{username} hat die Diskussion gepinnt."
-      discussion_unstickied_text: "{username} hat eine Diskussion von mir gelöst."
+      discussion_unstickied_text: "{username} hat die Diskussion gelöst."
 
   ##
   # REUSED STRINGS - These keys should not be used directly in code!

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -79,9 +79,9 @@ flarum-tags:
 
     # These strings are displayed between posts in the post stream.
     post_stream:
-      added_tags_text: "{username} hat die Kategorie {tagsAdded} hinzugefügt."
-      added_and_removed_tags_text: "{username} hat die Kategorie {tagsAdded} hinzugefügt und die Kategorie {tagsRemoved} entfernt."
-      removed_tags_text: "{username} hat die Kategorie {tagsRemoved} entfernt."
+      added_tags_text: "{username} hat die {tagsAdded} hinzugefügt."
+      added_and_removed_tags_text: "{username} hat die {tagsAdded} hinzugefügt und die {tagsRemoved} entfernt."
+      removed_tags_text: "{username} hat die {tagsRemoved} entfernt."
       tags_text: "{tags} Kategorie|{tags} Kategorien"
 
   # Strings in this namespace are used by the forum and admin interfaces.

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -33,7 +33,7 @@ flarum-tags:
     permissions:
       allow_edit_tags_label: Erlaube Kategorien zu ändern
       restrict_by_tag_heading: Durch Kategorien beschränken
-      tag_discussions_label: Diskussionen markieren
+      tag_discussions_label: Diskussion markieren
 
     # These strings are used in the Tag Settings modal dialog.
     tag_settings:

--- a/locale/flarum-tags.yml
+++ b/locale/flarum-tags.yml
@@ -33,7 +33,7 @@ flarum-tags:
     permissions:
       allow_edit_tags_label: Erlaube Kategorien zu ändern
       restrict_by_tag_heading: Durch Kategorien beschränken
-      tag_discussions_label: Diskussion markieren
+      tag_discussions_label: Diskussionen markieren
 
     # These strings are used in the Tag Settings modal dialog.
     tag_settings:


### PR DESCRIPTION
Die Antwort auf einen Post wurde fälschlicherweise so formuliert, das
auf seinen eigenen Post geantwortet wurde, wobei man diesen Post nicht
verfasst hat. Ich bin mir nicht so ganz sicher, wozu
mentioned_by_self_text verwendet wird, ein Vorkommniss ist mir noch
nicht erschienen.